### PR TITLE
navigation.goBack(null) and fix SearchBar cancelButtonText

### DIFF
--- a/src/Header.js
+++ b/src/Header.js
@@ -7,7 +7,8 @@ import {
   StyleSheet,
   View,
 } from 'react-native';
-import { withNavigation, HeaderBackButton } from 'react-navigation';
+import { withNavigation } from 'react-navigation';
+import { HeaderBackButton } from 'react-navigation-stack';
 import { getInset, getStatusBarHeight } from 'react-native-safe-area-view';
 import { isIphoneX } from 'react-native-iphone-x-helper';
 

--- a/src/SearchBar.ios.js
+++ b/src/SearchBar.ios.js
@@ -178,7 +178,7 @@ export default class SearchBar extends React.PureComponent {
     if (this.props.onCancelPress) {
       this.props.onCancelPress(this.props.navigation.goBack);
     } else {
-      this.props.navigation.goBack(null);
+      this.props.navigation.goBack();
     }
   };
 }

--- a/src/SearchBar.ios.js
+++ b/src/SearchBar.ios.js
@@ -178,7 +178,7 @@ export default class SearchBar extends React.PureComponent {
     if (this.props.onCancelPress) {
       this.props.onCancelPress(this.props.navigation.goBack);
     } else {
-      this.props.navigation.goBack();
+      this.props.navigation.goBack(null);
     }
   };
 }

--- a/src/SearchLayout.js
+++ b/src/SearchLayout.js
@@ -50,6 +50,7 @@ export default class SearchLayout extends React.Component {
             tintColor={
               this.props.searchInputTintColor || this.props.headerTintColor
             }
+            cancelButtonText={this.props.cancelButtonText}
           />
         </Header>
 


### PR DESCRIPTION
- Add null parameter, If null parameter is not present it won't go back when the Search Screen is a part of a top-level Navigator.
- Fix SearchBar cancelButtonText.
- Fix HeaderBackButton import