### PR TITLE
Update Header.js

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-navigation-addon-search-layout",
-  "version": "0.15.1",
+  "version": "0.1.7",
   "main": "index.js",
   "license": "MIT",
   "types": "index.d.ts",

--- a/lib/src/Header.js
+++ b/lib/src/Header.js
@@ -7,7 +7,7 @@ import {
   View,
 } from 'react-native';
 
-import { HeaderBackButton } from '@react-navigation/stack';
+import { HeaderBackButton } from '@react-navigation/elements';
 import { getStatusBarHeight } from 'react-native-safe-area-view';
 import { isIphoneX } from 'react-native-iphone-x-helper';
 import { useNavigation } from '@react-navigation/native';


### PR DESCRIPTION
Support React-navigation v6
- moved `HeaderBackButton` to `import { HeaderBackButton } from '@react-navigation/elements'`;